### PR TITLE
Tell CraftCMS not to alter response headers

### DIFF
--- a/src/services/Sso.php
+++ b/src/services/Sso.php
@@ -17,6 +17,7 @@ use nystudio107\vanillaforums\models\SsoData;
 
 use Craft;
 use craft\base\Component;
+use craft\web\Response;
 
 require_once(__DIR__.'/../lib/jsConnectPHP/functions.jsconnect.php');
 
@@ -67,6 +68,7 @@ class Sso extends Component
         $result = '';
         $settings = $this->getPluginSettings();
         $ssoData = $this->getSsoData($userId);
+        Craft::$app->getResponse()->format = Response::FORMAT_RAW;
         if ($ssoData !== null) {
             $request = Craft::$app->getRequest();
             //ob_start(); // Start output buffering


### PR DESCRIPTION
Without setting response format to "raw" `Craft::$app->end();` will replace the Content-Type header to be "text/html".

This results in 
> Cross-Origin Read Blocking (CORB) blocked cross-origin response https://craft-site/index.php?p=admin/actions/vanillaforums/sso/output&v=2&client_id=abc&ip=37.24.244.89&nonce=jsconnect_5eda5322862ab1.08145381&timestamp=1591366434&sig=abc&signature=def&Target=%2Fentry%2Fjsconnect&callback=jQuery110205567117790190508_1591366496488&_=1591366496489 with MIME type text/html. See https://www.chromestatus.com/feature/5629709824032768 for more details.