### PR TITLE
Breaking: rename SsoDataEvent::$data to SsoDataEvent::$ssoData

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -105,9 +105,9 @@ use nystudio107\vanillaforums\services\Sso;
 use nystudio107\vanillaforums\events\SsoDataEvent;
 
 Event::on(Sso::class,
-    SsoDataEvent::EVENT_SSO_DATA,
+    Sso::EVENT_SSO_DATA,
     function(SsoDataEvent $event) {
-        // potentially set $event->isValid or modify $event->data
+        // potentially set $event->isValid or modify $event->ssoData
     }
 );
 ```

--- a/src/events/SsoDataEvent.php
+++ b/src/events/SsoDataEvent.php
@@ -33,5 +33,5 @@ class SsoDataEvent extends ModelEvent
     /**
      * @var SsoData|null the SsoData model
      */
-    public $data;
+    public $ssoData;
 }

--- a/src/services/Sso.php
+++ b/src/services/Sso.php
@@ -148,14 +148,14 @@ class Sso extends Component
         // Give plugins a chance to modify it
         $event = new SsoDataEvent([
             'user' => $user,
-            'data' => $data,
+            'ssoData' => $data,
         ]);
         $this->trigger(self::EVENT_SSO_DATA, $event);
         if (!$event->isValid) {
             return null;
         }
 
-        return $data;
+        return $event->ssoData;
     }
 
     /**


### PR DESCRIPTION
There already is a yii\base\Event::$data and logic that overwrites
the $data property for every event handler invocation. (see
yii\base\Component::trigger)